### PR TITLE
ci: remove Azure App Service deployment steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,23 +1,21 @@
-name: Dev - Deploy
+name: Build
 
 on:
   push:
     branches:
       - main
   workflow_dispatch:
-    
+
 jobs:
-  deploy_prd:
+  build:
     runs-on: ubuntu-latest
-    name: Deploy to dev App Service
-    environment:
-      name: 'Production'
+    name: Build frontend
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
         ref: main
 
     - name: Get the latest tag
@@ -27,12 +25,12 @@ jobs:
         latest_tag=$(git describe --tags --abbrev=0 || echo "v0.0.0")
         echo "Latest tag: $latest_tag"
         echo "latest_tag=$latest_tag" >> $GITHUB_ENV
-    
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '22'
-    
+
     - name: Install Yarn
       run: npm install -g yarn
 
@@ -41,10 +39,3 @@ jobs:
 
     - name: Build frontend
       run: yarn run build
-
-    - name: Deploy to Azure Web App
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: "app-cosmic-dev-fe-01"
-        publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-        package: ./dist

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,11 +7,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy_prd:
+  build:
     runs-on: ubuntu-latest
-    name: Deploy to dev App Service
-    environment:
-      name: 'Production'
+    name: Build frontend
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Azure App Service (app-cosmic-dev-fe-01) is no longer active. Removed the azure/webapps-deploy step and Production environment reference to prevent workflow failures. Build steps are retained as CI checks.