### PR TITLE
Update frontend to v2 DB schema field names

### DIFF
--- a/src/api/documents/documentApi.ts
+++ b/src/api/documents/documentApi.ts
@@ -31,12 +31,12 @@ export interface Document {
   document_id: number;
   name: string;
   created_at: string;
-  file_url: string | null;
+  storage_path: string | null;
   file_signed_url: string | null;
   task_id: number | null;
   location_id: string | null;
   room_id: number | null;
-  user_id: number | null;
+  uploaded_by_user_id: number | null;
 }
 
 // New document interface for all_documents endpoint
@@ -45,9 +45,9 @@ export interface DocumentItem {
   created_at: string;
   name: string;
   task_id: number | null;
-  file_url: string | null;
+  storage_path: string | null;
   room_id: number;
-  user_id: number | null;
+  uploaded_by_user_id: number | null;
   location_id: string | null;
 }
 

--- a/src/api/lists/listsApi.ts
+++ b/src/api/lists/listsApi.ts
@@ -7,10 +7,10 @@ export interface ListTask {
   title: string;
   description: string;
   status: string;
-  dueDate: string;
+  due_at: string | null;
   priority: string | null;
-  user_id: number | null;
-  activity_id: number;
+  created_by_user_id: number | null;
+  task_type: string | null;
   location_id: string;
   assignee: {
     user_id: number;
@@ -18,18 +18,14 @@ export interface ListTask {
     first_name: string;
     last_name: string;
   } | null;
-  activity: {
-    activity_id: number;
-    name: string;
-  };
   documents: Array<{
     document_id: number;
     created_at: string;
     name: string;
     task_id: number;
-    file_url: string | null;
+    storage_path: string | null;
     room_id: number;
-    user_id: number | null;
+    uploaded_by_user_id: number | null;
     location_id: string | null;
   }>;
 }

--- a/src/api/locationApi/locationApi.ts
+++ b/src/api/locationApi/locationApi.ts
@@ -66,12 +66,9 @@ export interface Task {
   title: string;
   description: string;
   status: string;
-  dueDate: string;
+  due_at: string | null;
   priority: number;
-  activity: {
-    activity_id: number;
-    name: string;
-  };
+  task_type: string | null;
   location: {
     location_id: string;
     created_at: string;

--- a/src/api/notifications/notificationApi.ts
+++ b/src/api/notifications/notificationApi.ts
@@ -6,7 +6,7 @@ export interface Notification {
   created_at: string;
   name: string;
   text: string;
-  is_new: boolean;
+  read_at: string | null;
   type: string;
   user_id: number;
   room_id: number;
@@ -20,18 +20,18 @@ export interface NotificationRoom {
   room_id: number;
   room_name: string;
   notifications: Notification[];
-  newCount: number;
+  unreadCount: number;
 }
 
 export interface NotificationFloor {
   floor_id: number;
   floor_name: string;
-  newCount: number;
+  unreadCount: number;
   rooms: NotificationRoom[];
 }
 
 export interface NotificationsResponse {
-  totalNewCount: number;
+  totalUnreadCount: number;
   floors: NotificationFloor[];
 }
 
@@ -50,7 +50,6 @@ export interface CreateNotificationPayload {
   name: string;
   text: string;
   type: string;
-  is_new: boolean;
   room_id?: number;
   location_id?: string;
   document_id?: number;

--- a/src/api/tasks/taskApi.ts
+++ b/src/api/tasks/taskApi.ts
@@ -6,10 +6,10 @@ export interface TaskPayload {
   description?: string;
   status?: string;
   location_id?: string;
-  activity_id?: number;
-  user_id?: number;
-  dueDate?: string;
-  reccuring_id?: number;
+  task_type?: string;
+  created_by_user_id?: number;
+  due_at?: string;
+  recurrence_rule?: string;
   lists_ids?: number[];
 }
 
@@ -20,19 +20,14 @@ export interface Assignee {
   last_name: string;
 }
 
-export interface Activity {
-  activity_id: number;
-  name: string;
-}
-
 export interface Document {
   document_id: number;
   created_at: string;
   name: string;
   task_id: number;
-  file_url: string | null;
+  storage_path: string | null;
   room_id: number;
-  user_id: number | null;
+  uploaded_by_user_id: number | null;
   location_id: string | null;
 }
 
@@ -57,10 +52,10 @@ export interface TaskDetail {
   title: string;
   description: string;
   status: string;
-  dueDate: string;
+  due_at: string | null;
   priority: string | null;
   assignee: Assignee;
-  activity: Activity;
+  task_type: string | null;
   locations: Location;
 }
 
@@ -71,14 +66,11 @@ export interface TaskDetailSingle {
   title: string;
   description: string;
   status: string;
-  dueDate: string | null;
+  due_at: string | null;
   priority: string | null;
   assignee: Assignee;
-  activity: Activity;
-  reccuring: {
-    reccuring_id: number;
-    name: string;
-  };
+  task_type: string | null;
+  recurrence_rule: string | null;
   location: Location;
   documents: Document[];
   lists: Array<{
@@ -95,11 +87,11 @@ export interface TaskCreateResponse {
     title: string;
     description: string;
     status: string;
-    dueDate: string;
+    due_at: string | null;
     priority: string | null;
-    user_id: number;
-    activity_id: number;
-    reccuring_id: number;
+    created_by_user_id: number | null;
+    task_type: string | null;
+    recurrence_rule: string | null;
     location_id: string;
     lists_id?: number;
   };

--- a/src/features/calendar/CalendarWindow.tsx
+++ b/src/features/calendar/CalendarWindow.tsx
@@ -105,7 +105,7 @@ export function CalendarWindow() {
           case 'Status':
             return task.status === filter.value;
           case 'Task type':
-            return task.activity?.name === filter.value;
+            return task.task_type === filter.value;
           case 'Assignee':
             return (
               (task.assignee?.first_name + ' ' + task.assignee?.last_name).trim() === filter.value
@@ -118,8 +118,8 @@ export function CalendarWindow() {
             return task.locations?.room_id?.toString() === filter.value;
           case 'Due date':
             // Handle due date filtering based on the specific value
-            if (!task.dueDate) return false;
-            const taskDate = new Date(task.dueDate);
+            if (!task.due_at) return false;
+            const taskDate = new Date(task.due_at);
             const today = new Date();
 
             switch (filter.value) {
@@ -162,8 +162,8 @@ export function CalendarWindow() {
     });
 
     filteredTasks.forEach(task => {
-      if (task.dueDate) {
-        const taskDate = new Date(task.dueDate);
+      if (task.due_at) {
+        const taskDate = new Date(task.due_at);
         const existingDateIndex = datesWithTasks.findIndex(
           dateWithTasks =>
             dateWithTasks.date.getDate() === taskDate.getDate() &&
@@ -175,7 +175,7 @@ export function CalendarWindow() {
           datesWithTasks[existingDateIndex].tasks.push({
             id: task.task_id,
             name: task.title,
-            dueDate: task.dueDate,
+            dueDate: task.due_at,
           });
         } else {
           datesWithTasks.push({
@@ -184,7 +184,7 @@ export function CalendarWindow() {
               {
                 id: task.task_id,
                 name: task.title,
-                dueDate: task.dueDate,
+                dueDate: task.due_at,
               },
             ],
           });

--- a/src/features/dashboard/DashboardWindow.tsx
+++ b/src/features/dashboard/DashboardWindow.tsx
@@ -74,9 +74,9 @@ export const DashboardWindow = () => {
   const notifications = [
     ...(notificationsResponse?.floors?.flatMap(f => f.rooms).flatMap(r => r.notifications) || []),
   ].sort((a, b) => {
-    // First priority: new notifications come first
-    if (a.is_new && !b.is_new) return -1;
-    if (!a.is_new && b.is_new) return 1;
+    // First priority: unread notifications come first
+    if (a.read_at === null && b.read_at !== null) return -1;
+    if (a.read_at !== null && b.read_at === null) return 1;
 
     // Second priority: newest notifications first (by created_at)
     const dateA = new Date(a.created_at).getTime();

--- a/src/features/documentInfo/DocumentInfoWindow.tsx
+++ b/src/features/documentInfo/DocumentInfoWindow.tsx
@@ -85,16 +85,16 @@ export const DocumentInfoWindow = () => {
       setTempDocumentName(document.name);
 
       // Set the document URL from the API response
-      if (document.file_signed_url || document.file_url) {
+      if (document.file_signed_url || document.storage_path) {
         const url = constructDocumentUrl(
-          document.file_url || '',
+          document.storage_path || '',
           document.file_signed_url || undefined
         );
         setPdfUrl(url);
         setIsFileLoading(true); // Start file loading
 
         // Check if it's an image file
-        const imageFile = isImageFile(document.file_url || '');
+        const imageFile = isImageFile(document.storage_path || '');
         setIsImage(imageFile);
 
         // Reset page controls for images

--- a/src/features/list/components/AddTaskToListModal.tsx
+++ b/src/features/list/components/AddTaskToListModal.tsx
@@ -92,7 +92,7 @@ export const AddTaskToListModal = ({
         case 'Status':
           return filterValues.some(value => task.status === value);
         case 'Task type':
-          return filterValues.some(value => task.activity?.name === value);
+          return filterValues.some(value => task.task_type === value);
         case 'Assignee':
           return filterValues.some(
             value => (task.assignee?.first_name + ' ' + task.assignee?.last_name).trim() === value
@@ -104,8 +104,8 @@ export const AddTaskToListModal = ({
         case 'Room':
           return filterValues.some(value => task.locations?.room_id?.toString() === value);
         case 'Due date':
-          if (!task.dueDate) return false;
-          const taskDate = new Date(task.dueDate);
+          if (!task.due_at) return false;
+          const taskDate = new Date(task.due_at);
           const today = new Date();
 
           return filterValues.some(filterValue => {

--- a/src/features/mattertag/components/ObjectInfoTab.tsx
+++ b/src/features/mattertag/components/ObjectInfoTab.tsx
@@ -33,7 +33,7 @@ export const ObjectInfoTab = ({ tag, handleClose, locationData }: ObjectInfoTabP
           id: task.task_id,
           name: task.title || 'Untitled Task',
           status: task.status || 'Unknown Status',
-          activity: task.activity?.name || 'Unknown Activity',
+          activity: task.task_type || 'Unknown Activity',
         };
       })
     : [];

--- a/src/features/notifications/NotificationWindow.tsx
+++ b/src/features/notifications/NotificationWindow.tsx
@@ -124,11 +124,11 @@ export const NotificationWindow = () => {
           ?.rooms.flatMap(r => r.notifications) || [];
     }
 
-    // Sort notifications: new notifications first, then by creation date (newest first)
+    // Sort notifications: unread notifications first, then by creation date (newest first)
     return notifications.sort((a, b) => {
-      // First priority: new notifications come first
-      if (a.is_new && !b.is_new) return -1;
-      if (!a.is_new && b.is_new) return 1;
+      // First priority: unread notifications come first
+      if (a.read_at === null && b.read_at !== null) return -1;
+      if (a.read_at !== null && b.read_at === null) return 1;
 
       // Second priority: newest notifications first (by created_at)
       const dateA = new Date(a.created_at).getTime();
@@ -601,7 +601,7 @@ export const NotificationWindow = () => {
                   >
                     {notification.name}
                   </Typography>
-                  {notification.is_new && (
+                  {notification.read_at === null && (
                     <NewBadge>
                       <Typography>New</Typography>
                     </NewBadge>

--- a/src/features/task/TaskWindow.tsx
+++ b/src/features/task/TaskWindow.tsx
@@ -110,8 +110,8 @@ export const TaskWindow = () => {
       let parsedDueDate = '00.00.0000';
       let parsedDueTime = '00:00';
 
-      if (apiTask.dueDate) {
-        const date = new Date(apiTask.dueDate);
+      if (apiTask.due_at) {
+        const date = new Date(apiTask.due_at);
         const day = date.getDate().toString().padStart(2, '0');
         const month = (date.getMonth() + 1).toString().padStart(2, '0');
         const year = date.getFullYear();
@@ -127,7 +127,7 @@ export const TaskWindow = () => {
         apiTask.location?.location_name || apiTask.title.split('|')[1]?.trim() || '';
 
       const newLocalTask = {
-        type: apiTask.activity?.name || 'Select Action',
+        type: apiTask.task_type || 'Select Action',
         name: locationName,
         status: apiTask.status || '',
         assignee: apiTask.assignee
@@ -136,7 +136,7 @@ export const TaskWindow = () => {
         lists: apiTask.lists || [],
         dueTime: parsedDueTime,
         dueDate: parsedDueDate,
-        recurring: apiTask.reccuring?.name || 'No',
+        recurring: apiTask.recurrence_rule || 'No',
         description: apiTask.description || '',
         tags: [],
       };
@@ -236,7 +236,7 @@ export const TaskWindow = () => {
   };
 
   // Live edit handlers
-  const handleTypeSelect = async (newType: string, activityId: number) => {
+  const handleTypeSelect = async (newType: string) => {
     if (!taskId || !taskResponse?.task) return;
 
     // Update local state immediately
@@ -252,7 +252,7 @@ export const TaskWindow = () => {
       await updateTask({
         id: taskId,
         payload: {
-          activity_id: activityId,
+          task_type: newType,
           title: newTitle,
           location_id: taskResponse.task.location.location_id,
         },
@@ -284,8 +284,8 @@ export const TaskWindow = () => {
     setLocalTask(prev => ({ ...prev, name: newName }));
 
     try {
-      // Get current activity name from task response
-      const currentActivityName = taskResponse.task.activity?.name || task.type;
+      // Get current task type from task response
+      const currentActivityName = taskResponse.task.task_type || task.type;
 
       // Create new title without separator
       const newTitle = `${currentActivityName} ${newName}`;
@@ -361,7 +361,7 @@ export const TaskWindow = () => {
       await updateTask({
         id: taskId,
         payload: {
-          user_id: userId,
+          created_by_user_id: userId,
           location_id: taskResponse.task.location.location_id,
         },
       });
@@ -435,7 +435,7 @@ export const TaskWindow = () => {
     setIsListModalOpen(true);
   };
 
-  const handleRecurringSelect = async (newRecurring: string, recurringId: number) => {
+  const handleRecurringSelect = async (newRecurring: string) => {
     if (!taskId || !taskResponse?.task) return;
 
     // Update local state immediately
@@ -445,7 +445,7 @@ export const TaskWindow = () => {
       await updateTask({
         id: taskId,
         payload: {
-          reccuring_id: recurringId,
+          recurrence_rule: newRecurring,
           location_id: taskResponse.task.location.location_id,
         },
       });
@@ -486,7 +486,7 @@ export const TaskWindow = () => {
       await updateTask({
         id: taskId,
         payload: {
-          dueDate: isoDate,
+          due_at: isoDate,
           location_id: taskResponse.task.location.location_id,
         },
       });
@@ -527,7 +527,7 @@ export const TaskWindow = () => {
       await updateTask({
         id: taskId,
         payload: {
-          dueDate: isoDate,
+          due_at: isoDate,
           location_id: taskResponse.task.location.location_id,
         },
       });

--- a/src/features/task/components/RecurringModal.tsx
+++ b/src/features/task/components/RecurringModal.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 interface RecurringModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (recurring: string, recurringId: number) => void;
+  onSelect: (recurring: string) => void;
   currentRecurring: string;
   anchorEl: HTMLElement | null;
 }
@@ -69,7 +69,7 @@ export const RecurringModal = ({
           <MenuItem
             key={option.id}
             onClick={() => {
-              onSelect(option.name, option.id);
+              onSelect(option.name);
               onClose();
             }}
             sx={{

--- a/src/features/task/components/TypeModal.tsx
+++ b/src/features/task/components/TypeModal.tsx
@@ -3,7 +3,7 @@ import { Menu, MenuItem } from '@mui/material';
 interface TypeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (type: string, activityId: number) => void;
+  onSelect: (type: string) => void;
   currentType: string;
   anchorEl: HTMLElement | null;
   marginTop?: string;
@@ -73,7 +73,7 @@ export const TypeModal = ({
         <MenuItem
           key={type.id}
           onClick={() => {
-            onSelect(type.name, type.id);
+            onSelect(type.name);
             onClose();
           }}
           sx={{

--- a/src/features/tasks/NewTaskWindow.tsx
+++ b/src/features/tasks/NewTaskWindow.tsx
@@ -73,10 +73,8 @@ export const NewTaskWindow = () => {
     dueTime: '00:00',
     dueDate: '00.00.0000',
     recurring: '',
-    recurringId: 1,
     description: '',
     tags: [],
-    activityId: 0,
     locationId: '',
   };
   const [task, setTask] = useState(defaultTaskState);
@@ -181,8 +179,8 @@ export const NewTaskWindow = () => {
     setValidationErrors({});
   };
 
-  const handleTypeSelect = (newType: string, activityId: number) => {
-    setTask(prev => ({ ...prev, type: newType, activityId }));
+  const handleTypeSelect = (newType: string) => {
+    setTask(prev => ({ ...prev, type: newType }));
     clearValidationError('type');
   };
 
@@ -233,8 +231,8 @@ export const NewTaskWindow = () => {
     setIsListModalOpen(true);
   };
 
-  const handleRecurringSelect = (newRecurring: string, recurringId: number) => {
-    setTask(prev => ({ ...prev, recurring: newRecurring, recurringId }));
+  const handleRecurringSelect = (newRecurring: string) => {
+    setTask(prev => ({ ...prev, recurring: newRecurring }));
   };
 
   const handleRecurringClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -284,10 +282,10 @@ export const NewTaskWindow = () => {
         title,
         description: task.description,
         status: task.status,
-        dueDate,
-        activity_id: task.activityId,
-        user_id: task.assigneeId || undefined,
-        reccuring_id: task.recurringId,
+        due_at: dueDate,
+        task_type: task.type || undefined,
+        created_by_user_id: task.assigneeId || undefined,
+        recurrence_rule: task.recurring || undefined,
         location_id: task.locationId || undefined,
         lists_id: task.listId || undefined,
       };

--- a/src/features/tasks/components/TasksTab.tsx
+++ b/src/features/tasks/components/TasksTab.tsx
@@ -88,7 +88,7 @@ export const TasksTab = ({
         case 'Status':
           return filterValues.some(value => task.status === value);
         case 'Task type':
-          return filterValues.some(value => task.activity?.name === value);
+          return filterValues.some(value => task.task_type === value);
         case 'Assignee':
           return filterValues.some(
             value => (task.assignee?.first_name + ' ' + task.assignee?.last_name).trim() === value
@@ -100,8 +100,8 @@ export const TasksTab = ({
         case 'Room':
           return filterValues.some(value => task.locations?.room_id?.toString() === value);
         case 'Due date':
-          if (!task.dueDate) return false;
-          const taskDate = new Date(task.dueDate);
+          if (!task.due_at) return false;
+          const taskDate = new Date(task.due_at);
           const today = new Date();
 
           return filterValues.some(filterValue => {

--- a/src/utils/notificationUtils.ts
+++ b/src/utils/notificationUtils.ts
@@ -38,7 +38,6 @@ export const createNotification = async (
       name: notificationData.name,
       text: notificationData.text,
       type: notificationData.type,
-      is_new: true,
       room_id: notificationData.room_id || room_id,
       location_id: notificationData.location_id,
       document_id: notificationData.document_id,


### PR DESCRIPTION
Rename API fields throughout to match the migrated backend schema:
- task_type (string) replaces activity_id + activity object
- recurrence_rule (string) replaces reccuring_id + reccuring object
- created_by_user_id replaces user_id on tasks
- due_at replaces dueDate on tasks
- storage_path replaces file_url on documents
- uploaded_by_user_id replaces user_id on documents
- read_at (nullable) replaces is_new boolean on notifications
- unreadCount/totalUnreadCount replace newCount/totalNewCount

Updated: taskApi, documentApi, notificationApi, listsApi, locationApi, notificationUtils, TaskWindow, TypeModal, RecurringModal, NewTaskWindow, TasksTab, NotificationWindow, DashboardWindow, AddTaskToListModal, CalendarWindow, ObjectInfoTab, DocumentInfoWindow

https://claude.ai/code/session_01HtVu1gx64C7aJ7ZbkMr1Eq