### PR TITLE
fix: remove unused TypeScript variables causing build failure

### DIFF
--- a/src/api/reconstruction/reconstructionApi.ts
+++ b/src/api/reconstruction/reconstructionApi.ts
@@ -142,7 +142,7 @@ export const reconstructionApi = createApi({
       }),
       transformResponse: (response: { data: ReconstructionJob }) =>
         response.data,
-      providesTags: (result, error, jobId) => [
+      providesTags: (_result, _error, jobId) => [
         { type: 'ReconstructionJobs', id: jobId },
       ],
     }),

--- a/src/features/reconstruction/ReconstructionWindow.tsx
+++ b/src/features/reconstruction/ReconstructionWindow.tsx
@@ -9,10 +9,8 @@ import {
   Button,
   TextField,
   LinearProgress,
-  Select,
-  MenuItem,
 } from '@mui/material';
-import { useCallback, useState, useEffect, useRef } from 'react';
+import { useCallback, useState } from 'react';
 import {
   useCreateJobMutation,
   useStartJobMutation,


### PR DESCRIPTION
- Prefix result/error params with _ in providesTags callback
- Remove unused Select, MenuItem, useEffect, useRef imports from ReconstructionWindow

https://claude.ai/code/session_01PswXHzivM15VKrsYXNXJz2