### PR TITLE
feat: Gaussian Splat Viewer für abgeschlossene Rekonstruktionsjobs (#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@matterport/sdk": "^1.4.24",
+        "@mkkellogg/gaussian-splats-3d": "^0.4.7",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.0",
         "@radix-ui/react-popover": "^1.1.14",
@@ -22,6 +23,7 @@
         "@types/react-dnd": "^3.0.2",
         "@types/react-pdf": "^6.2.0",
         "@types/sortablejs": "^1.15.8",
+        "@types/three": "^0.183.1",
         "antd": "^5.25.3",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
@@ -40,7 +42,8 @@
         "react-router-dom": "^6.22.3",
         "sortablejs": "^1.15.6",
         "tailwind-merge": "^3.3.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "three": "^0.183.2"
       },
       "devDependencies": {
         "@types/react": "^18.2.64",
@@ -670,6 +673,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
@@ -1570,6 +1579,15 @@
       "resolved": "https://registry.npmjs.org/@matterport/sdk/-/sdk-1.4.24.tgz",
       "integrity": "sha512-w+K8pxZC0hSRfapF8jHLxDl75y8TPgtjICk0DPc1l2RbaDU8+kheRCFpgSdEYOd3HO4WD5uNsUG65qljqgDDeg==",
       "license": "SEE LICENSE IN LICENSE.md"
+    },
+    "node_modules/@mkkellogg/gaussian-splats-3d": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@mkkellogg/gaussian-splats-3d/-/gaussian-splats-3d-0.4.7.tgz",
+      "integrity": "sha512-0vy9/i9sJLFH/v3WJZ4axCsqjkToe8UsV3xY7bvK5EUC0akiRsWZODoCiSzpxhTLNyzSKTsyQKozIFeNA5RWRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.160.0"
+      }
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.1.0",
@@ -3140,6 +3158,12 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3193,16 +3217,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "20.17.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
-      "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -3286,10 +3300,37 @@
       "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
       "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg=="
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.183.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
+      "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.0.1"
+      }
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.2.0",
@@ -3506,6 +3547,12 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@zxcvbn-ts/core": {
       "version": "3.0.4",
@@ -4761,6 +4808,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5640,6 +5693,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
+      "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7912,6 +7971,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
     "node_modules/throttle-debounce": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
@@ -8053,13 +8118,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@matterport/sdk": "^1.4.24",
+    "@mkkellogg/gaussian-splats-3d": "^0.4.7",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.0",
     "@radix-ui/react-popover": "^1.1.14",
@@ -27,6 +28,7 @@
     "@types/react-dnd": "^3.0.2",
     "@types/react-pdf": "^6.2.0",
     "@types/sortablejs": "^1.15.8",
+    "@types/three": "^0.183.1",
     "antd": "^5.25.3",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
@@ -45,7 +47,8 @@
     "react-router-dom": "^6.22.3",
     "sortablejs": "^1.15.6",
     "tailwind-merge": "^3.3.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "three": "^0.183.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/src/api/reconstruction/reconstructionApi.ts
+++ b/src/api/reconstruction/reconstructionApi.ts
@@ -142,7 +142,7 @@ export const reconstructionApi = createApi({
       }),
       transformResponse: (response: { data: ReconstructionJob }) =>
         response.data,
-      providesTags: (result, error, jobId) => [
+      providesTags: (_result, _error, jobId) => [
         { type: 'ReconstructionJobs', id: jobId },
       ],
     }),

--- a/src/features/reconstruction/ReconstructionWindow.tsx
+++ b/src/features/reconstruction/ReconstructionWindow.tsx
@@ -9,10 +9,10 @@ import {
   Button,
   TextField,
   LinearProgress,
-  Select,
-  MenuItem,
 } from '@mui/material';
-import { useCallback, useState, useEffect, useRef } from 'react';
+import ThreeDRotationIcon from '@mui/icons-material/ThreeDRotation';
+import { useCallback, useState } from 'react';
+import { SplatViewer } from './SplatViewer';
 import {
   useCreateJobMutation,
   useStartJobMutation,
@@ -605,6 +605,9 @@ const JobDetail = ({
   const { data: output } = useGetJobOutputQuery(jobId, {
     skip: job?.status !== 'completed',
   });
+  const [splatViewerUrl, setSplatViewerUrl] = useState<string | null>(null);
+
+  const viewableSplatUrl = output?.splat_url || output?.spz_url || null;
 
   if (isLoading || !job) {
     return (
@@ -738,6 +741,35 @@ const JobDetail = ({
             <DownloadButton label="SPZ Datei" url={output.spz_url} />
           )}
         </Box>
+      )}
+
+      {/* 3D Viewer button */}
+      {job.status === 'completed' && viewableSplatUrl && (
+        <Button
+          onClick={() => setSplatViewerUrl(viewableSplatUrl)}
+          startIcon={<ThreeDRotationIcon />}
+          sx={{
+            width: '100%',
+            height: '48px',
+            borderRadius: '20px',
+            backgroundColor: 'rgba(33, 150, 243, 0.15)',
+            color: '#2196F3',
+            textTransform: 'none',
+            fontSize: '14px',
+            fontWeight: 600,
+            '&:hover': { backgroundColor: 'rgba(33, 150, 243, 0.25)' },
+          }}
+        >
+          3D ansehen
+        </Button>
+      )}
+
+      {/* Splat Viewer overlay */}
+      {splatViewerUrl && (
+        <SplatViewer
+          splatUrl={splatViewerUrl}
+          onClose={() => setSplatViewerUrl(null)}
+        />
       )}
 
       {/* Cancel button */}

--- a/src/features/reconstruction/SplatViewer.tsx
+++ b/src/features/reconstruction/SplatViewer.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Box, IconButton, CircularProgress, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { Viewer, SceneRevealMode } from '@mkkellogg/gaussian-splats-3d';
+
+interface SplatViewerProps {
+  splatUrl: string;
+  onClose?: () => void;
+}
+
+export const SplatViewer = ({ splatUrl, onClose }: SplatViewerProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewerRef = useRef<Viewer | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cleanup = useCallback(async () => {
+    if (viewerRef.current) {
+      const viewer = viewerRef.current;
+      viewerRef.current = null;
+      try {
+        await viewer.dispose();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !splatUrl) return;
+
+    let cancelled = false;
+
+    const initViewer = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const viewer = new Viewer({
+          rootElement: container,
+          selfDrivenMode: true,
+          useBuiltInControls: true,
+          cameraUp: [0, 1, 0],
+          initialCameraPosition: [0, 5, 10],
+          initialCameraLookAt: [0, 0, 0],
+          antialiased: true,
+          sceneRevealMode: SceneRevealMode.Gradual,
+          sharedMemoryForWorkers: false,
+          gpuAcceleratedSort: true,
+        });
+
+        if (cancelled) {
+          await viewer.dispose();
+          return;
+        }
+
+        viewerRef.current = viewer;
+
+        await viewer
+          .addSplatScene(splatUrl, {
+            showLoadingUI: false,
+            progressiveLoad: true,
+          })
+          .promise;
+
+        if (cancelled) return;
+
+        setIsLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Fehler beim Laden der 3D-Szene';
+        setError(message);
+        setIsLoading(false);
+      }
+    };
+
+    initViewer();
+
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, [splatUrl, cleanup]);
+
+  return (
+    <Box
+      sx={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        backgroundColor: '#0a0a0a',
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {/* Close button */}
+      <IconButton
+        onClick={onClose}
+        sx={{
+          position: 'absolute',
+          top: 16,
+          right: 16,
+          zIndex: 10000,
+          width: 44,
+          height: 44,
+          backgroundColor: 'rgba(46, 46, 46, 0.6)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          color: '#FFFFFF',
+          '&:hover': { backgroundColor: 'rgba(46, 46, 46, 0.85)' },
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
+
+      {/* Three.js container */}
+      <Box
+        ref={containerRef}
+        sx={{
+          width: '100%',
+          height: '100%',
+          '& canvas': {
+            display: 'block',
+            width: '100% !important',
+            height: '100% !important',
+          },
+        }}
+      />
+
+      {/* Loading overlay */}
+      {isLoading && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+            backgroundColor: 'rgba(10, 10, 10, 0.7)',
+            zIndex: 10001,
+            pointerEvents: 'none',
+          }}
+        >
+          <CircularProgress size={48} sx={{ color: '#FFFFFF' }} />
+          <Typography sx={{ color: '#FFFFFF80', fontSize: '14px' }}>
+            3D-Szene wird geladen...
+          </Typography>
+        </Box>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 2,
+            padding: '24px 32px',
+            borderRadius: '20px',
+            backgroundColor: 'rgba(46, 46, 46, 0.6)',
+            backdropFilter: 'blur(20px)',
+            WebkitBackdropFilter: 'blur(20px)',
+            zIndex: 10001,
+          }}
+        >
+          <Typography sx={{ color: '#FF6B6B', fontSize: '14px', fontWeight: 600 }}>
+            Fehler beim Laden
+          </Typography>
+          <Typography
+            sx={{
+              color: '#FFFFFF80',
+              fontSize: '12px',
+              textAlign: 'center',
+              maxWidth: '300px',
+            }}
+          >
+            {error}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/types/gaussian-splats-3d.d.ts
+++ b/src/types/gaussian-splats-3d.d.ts
@@ -1,0 +1,101 @@
+declare module '@mkkellogg/gaussian-splats-3d' {
+  import type { Vector3 } from 'three';
+
+  interface ViewerOptions {
+    cameraUp?: [number, number, number];
+    initialCameraPosition?: [number, number, number];
+    initialCameraLookAt?: [number, number, number];
+    selfDrivenMode?: boolean;
+    useBuiltInControls?: boolean;
+    rootElement?: HTMLElement;
+    dynamicScene?: boolean;
+    sharedMemoryForWorkers?: boolean;
+    renderMode?: number;
+    sceneRevealMode?: number;
+    antialiased?: boolean;
+    focalAdjustment?: number;
+    logLevel?: number;
+    sphericalHarmonicsDegree?: number;
+    enableOptionalEffects?: boolean;
+    plyInMemoryCompressionLevel?: number;
+    freeIntermediateSplatData?: boolean;
+    inMemoryCompressionLevel?: number;
+    enableSIMDInSort?: boolean;
+    gpuAcceleratedSort?: boolean;
+    integerBasedSort?: boolean;
+    halfPrecisionCovariancesOnGPU?: boolean;
+    threeScene?: unknown;
+    renderer?: unknown;
+    camera?: unknown;
+  }
+
+  interface AddSplatSceneOptions {
+    showLoadingUI?: boolean;
+    progressiveLoad?: boolean;
+    format?: number;
+    splatAlphaRemovalThreshold?: number;
+    position?: [number, number, number];
+    rotation?: [number, number, number, number];
+    scale?: [number, number, number];
+    onProgress?: (progress: number, message: string, stage: string) => void;
+  }
+
+  interface AbortablePromise<T = void> {
+    promise: Promise<T>;
+    then: (onResolve: (...args: unknown[]) => unknown) => AbortablePromise;
+    catch: (onFail: (error: Error) => void) => AbortablePromise;
+    abort: (reason?: string) => void;
+  }
+
+  export class Viewer {
+    constructor(options?: ViewerOptions);
+    addSplatScene(path: string, options?: AddSplatSceneOptions): AbortablePromise;
+    start(): void;
+    stop(): void;
+    dispose(): Promise<void>;
+    removeSplatScene(index: number): void;
+    setFocalLength(length: number): void;
+    getCamera(): unknown;
+    getRenderer(): unknown;
+    getScene(): unknown;
+    cameraUp: Vector3;
+    initialCameraPosition: Vector3;
+    initialCameraLookAt: Vector3;
+  }
+
+  export class DropInViewer extends Viewer {
+    constructor(options?: ViewerOptions);
+  }
+
+  export const LogLevel: {
+    None: number;
+    Error: number;
+    Warning: number;
+    Info: number;
+    Debug: number;
+  };
+
+  export const SceneRevealMode: {
+    Default: number;
+    Gradual: number;
+    Instant: number;
+  };
+
+  export const RenderMode: {
+    Always: number;
+    OnChange: number;
+    Never: number;
+  };
+
+  export const SceneFormat: {
+    Splat: number;
+    Ply: number;
+    Spz: number;
+    Ksplat: number;
+  };
+
+  export const SplatRenderMode: {
+    ThreeD: number;
+    TwoD: number;
+  };
+}


### PR DESCRIPTION
## Was wurde gebaut

Integiert den Gaussian Splat Viewer für die 3D Pipeline (Issue #13).

### Änderungen
- `@mkkellogg/gaussian-splats-3d` npm-Paket installiert
- Neue Komponente `SplatViewer.tsx`: rendert .splat/.spz Dateien in einem Canvas (Three.js-basiert), dark background, Loading-Spinner, Error-State, Close-Button
- `ReconstructionWindow.tsx` updated: Bei Status `completed` + vorhandener Splat-Output-URL erscheint ein '3D ansehen'-Button der den Viewer als fullscreen Dialog öffnet

### Nächste Schritte
- Backend Issue #34: CALLBACK_BASE_URL + CALLBACK_SECRET setzen damit Jobs wirklich 'completed' werden
- Frontend Issue #14: Matterport ↔️ Splat Switch-Mechanismus

Closes #13