### PR TITLE
feat: Cancel tag input on outside click + fix TS build error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary

- **Add Tags Button**: Klick auf „Add Tags" öffnet ein Text-Input-Feld (aktiver Zustand). Klick außerhalb des Containers bricht die Eingabe ab und zeigt den Button wieder an. Enter bestätigt den Tag, Escape bricht ab.
- **Fix Vercel Build**: `tsconfig.json` um `"ignoreDeprecations": "6.0"` ergänzt, um den TypeScript `TS5101`-Fehler (`baseUrl` deprecated) zu beheben.

## Test plan

- [ ] „Add Tags" Button in `NewTaskWindow` anklicken → Input-Feld erscheint
- [ ] Außerhalb des Tag-Bereichs klicken → Input verschwindet, Button erscheint wieder
- [ ] Tag-Namen eingeben + Enter → Tag wird als Chip hinzugefügt
- [ ] Escape drücken → Input wird abgebrochen
- [ ] Vercel Build läuft durch ohne `TS5101`-Fehler

https://claude.ai/code/session_01HU9X3k894JHKAa5FDUpTMv