### PR TITLE
fix: remove deprecated baseUrl from tsconfig to fix Vercel build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,10 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
-    "allowSyntheticDefaultImports": true,
-    "ignoreDeprecations": "6.0"
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary

Behebt den Vercel Build-Fehler auf `main`:

- `TS5101`: `baseUrl` ist in TypeScript 5.x deprecated
- `TS5103`: `"ignoreDeprecations": "6.0"` ist kein gültiger Wert in TypeScript 5.x

**Fix:** `baseUrl` und `ignoreDeprecations` entfernt. Mit `moduleResolution: "bundler"` unterstützt TypeScript 5.x `paths` ohne `baseUrl` — der `@/*`-Alias funktioniert weiterhin.

## Test plan

- [ ] Vercel Build auf `main` läuft durch ohne TS-Fehler

https://claude.ai/code/session_01HU9X3k894JHKAa5FDUpTMv