### PR TITLE
fix: type tags as string[] to fix final Vercel build error

### DIFF
--- a/src/features/tasks/NewTaskWindow.tsx
+++ b/src/features/tasks/NewTaskWindow.tsx
@@ -74,7 +74,7 @@ export const NewTaskWindow = () => {
     dueDate: '00.00.0000',
     recurring: '',
     description: '',
-    tags: [],
+    tags: [] as string[],
     locationId: '',
   };
   const [task, setTask] = useState(defaultTaskState);


### PR DESCRIPTION
## Summary

Letzter verbleibender Build-Fehler: TypeScript inferiert `tags: []` als `never[]`, was das Hinzufügen von `string`-Werten blockiert.

**Fix:** `tags: [] as string[]` — explizite Typisierung.

Der Build läuft lokal sauber durch (`✓ built in 17.78s`).

https://claude.ai/code/session_01HU9X3k894JHKAa5FDUpTMv